### PR TITLE
data bus mirroring from TG68K.C

### DIFF
--- a/lib/cpu/m68k/rtl/m68k.vhd
+++ b/lib/cpu/m68k/rtl/m68k.vhd
@@ -459,9 +459,16 @@ begin
     if memmaskmux(1) = '0' then
       data_write <= data_write_mux(47 downto 32);
     elsif memmaskmux(3) = '0' then
-      data_write <= data_write_mux(31 downto 16);
-    else
-      data_write <= data_write_mux(15 downto 0);
+       data_write <= data_write_mux(31 downto 16);
+     else
+-- a single byte shows up on both bus halfs
+      if memmaskmux(5 downto 4) = "10" then
+        data_write <= data_write_mux(7 downto 0) & data_write_mux(7 downto 0);
+      elsif memmaskmux(5 downto 4) = "01" then
+        data_write <= data_write_mux(15 downto 8) & data_write_mux(15 downto 8);
+      else
+        data_write <= data_write_mux(15 downto 0);
+      end if;
     end if;
 
     if exec.mem_byte = '1' then --movep


### PR DESCRIPTION
 The 68000 mirrors the same byte to the upper and lower bits of the data bus on a byte write
http://atari-forum.com/viewtopic.php?f=117&t=32761&sid=94eb62e31b04b17c6d4ca2a134b9d6b0&start=1250#p390548